### PR TITLE
fix: set sts client region

### DIFF
--- a/service/sts/config.go
+++ b/service/sts/config.go
@@ -65,9 +65,9 @@ func (p *STS) GetAPIInfo(api string) *base.ApiInfo {
 	return nil
 }
 
-// SetHost .
+// SetRegion .
 func (p *STS) SetRegion(region string) {
-	ServiceInfo.Credentials.Region = region
+	p.Client.ServiceInfo.Credentials.Region = region
 }
 
 // SetHost .


### PR DESCRIPTION
```golang
package main

import (
	"fmt"
	"github.com/volcengine/volc-sdk-golang/service/sts"
)

func main() {
	ins := sts.NewInstance()
	ins.SetRegion("cn-north-3")

	fmt.Println(ins.Client.ServiceInfo.Credentials.Region) // cn-north-1
	fmt.Println(ins.GetServiceInfo().Credentials.Region) // cn-north-3
}
```

in this case, i wanna call AssumeRole to get sts token, but it does not take effect to set region by `ins.SetRegion()`.

and then i find the source code:
```golang
func NewClient(info *ServiceInfo, apiInfoList map[string]*ApiInfo) *Client {
	client := &Client{Client: _GlobalClient, ServiceInfo: info.Clone(), ApiInfoList: apiInfoList}
	//...
}
```

Client in the sts instance use the clone of ServiceInfo, but `ins.SetRegion()` only modify `ServiceInfo` variable in sts config, actually Client's config has not modified.
