### PR TITLE
修复：老照片修复接口参数image_urls无法生效

### DIFF
--- a/service/visual/model/model_convert_photov2.go
+++ b/service/visual/model/model_convert_photov2.go
@@ -6,7 +6,7 @@ import "github.com/volcengine/volc-sdk-golang/base"
 
 type ConvertPhotoV2Request struct {
 	ReqKey           string   `json:"req_key"`
-	BinaryDataBase64 []string `json:"binary_data_base64"`
+	BinaryDataBase64 []string `json:"binary_data_base64,omitempty"`
 	ImageUrls        []string `json:"image_urls"`
 	IsColor          bool     `json:"is_color"` // Deprecated
 	IfColor          int      `json:"if_color"`


### PR DESCRIPTION
接口参数`BinaryDataBase64`未设置omitempty， 导致该参数始终被序列化且为首选参数. `image_urls` 无法生效

复现代码
```
import (
	"encoding/json"
	"fmt"
	"github.com/volcengine/volc-sdk-golang/service/visual"
	"github.com/volcengine/volc-sdk-golang/service/visual/model"
)

func main() {
	testAk := "ak"
	testSk := "sk"

	visual.DefaultInstance.Client.SetAccessKey(testAk)
	visual.DefaultInstance.Client.SetSecretKey(testSk)
	//visual.DefaultInstance.SetRegion("region")
	//visual.DefaultInstance.SetHost("host")

	//请求入参
	reqBody := &model.ConvertPhotoV2Request{
		ReqKey:    "lens_opr", // 固定值
		ImageUrls: []string{"https://portal.volccdn.com/obj/volcfe/cloud-universal-doc/upload_242ef2ec0f7d750f3a1d1f172e0e5145.jpg"},
		IfColor:   1,
	}

	resp, status, err := visual.DefaultInstance.ConvertPhotoV2(reqBody)
	fmt.Println(status, err)
	b, _ := json.Marshal(resp)
	fmt.Println(string(b))
}
```

输出
```
{"request_id":"20240722154025BA796EA8128A6798F6FE","code":50207,"message":"Image Decode Error: image format unsupported: invalid binary_data_base64 type=\u003cnil\u003e","status":50207,"time_elapsed":"3.147165ms","data":null}
```